### PR TITLE
fixing typo in notebook

### DIFF
--- a/No-Ones-Jupyter-Notebook.ipynb
+++ b/No-Ones-Jupyter-Notebook.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "## Level Finding\n",
     "\n",
-    ""An integer is *one-free* if none of its digits is 1. The *level* of a positive integer n is the smallest positive integer m such that n*m is one-free. The following cell defines a function that (by brute force) calculates the level of m if that level is less than some maximum value. If the level of n is undefined or exceeds the maximum value the function returns "error"."
+    "An integer is *one-free* if none of its digits is 1. The *level* of a positive integer n is the smallest positive integer m such that n*m is one-free. The following cell defines a function that (by brute force) calculates the level of m if that level is less than some maximum value. If the level of n is undefined or exceeds the maximum value the function returns \"error\"."
    ]
   },
   {


### PR DESCRIPTION
@steven-t-kuhn It looks Commiting a Suggestion doesn't work with notebooks and/or there was a typo in my suggestion.  There was an extra quotation mark and the places where we wanted quotation marks needed a different symbol in the raw text.  This should fix the issue.  Let's try it and find out!